### PR TITLE
chore(ci): 钉钉通知时带上组件版本号

### DIFF
--- a/notify.sh
+++ b/notify.sh
@@ -12,8 +12,9 @@ curl -H "Authorization: token $GITHUB_TOKEN" $url > $resp_tmp_file
 
 html_url=$(sed -n 5p $resp_tmp_file | sed 's/\"html_url\"://g' | awk -F '"' '{print $2}')
 body=$(grep body < $resp_tmp_file | sed 's/\"body\"://g;s/\"//g')
+version=$(echo $html_url | awk -F '/' '{print $NF}')
 
-msg='{"msgtype": "markdown", "markdown": {"title": "excel-it更新", "text": "@所有人\n# [excel-it]('$html_url')\n'$body'"}}'
+msg='{"msgtype": "markdown", "markdown": {"title": "excel-it更新", "text": "@所有人\n# [excel-it('$version')]('$html_url')\n'$body'"}}'
 
 curl -X POST https://oapi.dingtalk.com/robot/send\?access_token\=$DINGTALK_ROBOT_TOKEN -H 'Content-Type: application/json' -d "$msg"
 


### PR DESCRIPTION
## Why
让信息更透明，方便大家快速了解最新版本号

## How
从html_url变量中，获取版本号

## Test

![image](https://user-images.githubusercontent.com/9384365/66975368-e48fbd80-f0d0-11e9-90a8-965fbd6ad6d2.png)


